### PR TITLE
feat(smhc): add 15 SMHC registers, field access functions and unit test cases

### DIFF
--- a/src/ccu.rs
+++ b/src/ccu.rs
@@ -764,7 +764,10 @@ impl<const I: usize> ClockConfig for SPI<I> {
 
 #[cfg(test)]
 mod tests {
-    use super::RegisterBlock;
+    use super::{
+        CpuAxiConfig, CpuClockSource, FactorP, PllCpuControl, PllDdrControl, PllPeri0Control,
+        RegisterBlock,
+    };
     use memoffset::offset_of;
     #[test]
     fn offset_ccu() {
@@ -779,9 +782,290 @@ mod tests {
         assert_eq!(offset_of!(RegisterBlock, spi_clk), 0x940);
         assert_eq!(offset_of!(RegisterBlock, spi_bgr), 0x96c);
     }
+
+    #[test]
+    fn struct_pll_cpu_control_fuctions() {
+        let mut val = PllCpuControl(0x0);
+
+        val = val.enable_pll();
+        assert_eq!(val.0, 0x80000000);
+        assert!(val.is_pll_enabled());
+
+        val = val.disable_pll();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_pll_enabled());
+
+        val = val.enable_pll_ldo();
+        assert_eq!(val.0, 0x40000000);
+        assert!(val.is_pll_ldo_enabled());
+
+        val = val.disable_pll_ldo();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_pll_ldo_enabled());
+
+        val = val.enable_lock();
+        assert_eq!(val.0, 0x20000000);
+        assert!(val.is_lock_enabled());
+
+        val = val.disable_lock();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_lock_enabled());
+
+        let val = PllCpuControl(0x10000000);
+        assert!(val.is_locked());
+        let val = PllCpuControl(0x0);
+        assert!(!val.is_locked());
+
+        let mut val = PllCpuControl(0x0);
+
+        val = val.unmask_pll_output();
+        assert_eq!(val.0, 0x08000000);
+        assert!(val.is_pll_output_unmasked());
+
+        val = val.mask_pll_output();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_pll_output_unmasked());
+
+        val = val.set_pll_n(0xFF);
+        assert_eq!(val.0, 0x0000FF00);
+        assert_eq!(val.pll_n(), 0xFF);
+
+        val = val.set_pll_n(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.pll_n(), 0x0);
+
+        val = val.set_pll_m(0x03);
+        assert_eq!(val.0, 0x00000003);
+        assert_eq!(val.pll_m(), 0x03);
+
+        val = val.set_pll_m(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.pll_m(), 0x0);
+    }
+
+    #[test]
+    fn struct_pll_ddr_control_fuctions() {
+        let mut val = PllDdrControl(0x0);
+
+        val = val.enable_pll();
+        assert_eq!(val.0, 0x80000000);
+        assert!(val.is_pll_enabled());
+
+        val = val.disable_pll();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_pll_enabled());
+
+        val = val.enable_pll_ldo();
+        assert_eq!(val.0, 0x40000000);
+        assert!(val.is_pll_ldo_enabled());
+
+        val = val.disable_pll_ldo();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_pll_ldo_enabled());
+
+        val = val.enable_lock();
+        assert_eq!(val.0, 0x20000000);
+        assert!(val.is_lock_enabled());
+
+        val = val.disable_lock();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_lock_enabled());
+
+        let val = PllDdrControl(0x10000000);
+        assert!(val.is_locked());
+        let val = PllDdrControl(0x0);
+        assert!(!val.is_locked());
+
+        let mut val = PllDdrControl(0x0);
+
+        val = val.unmask_pll_output();
+        assert_eq!(val.0, 0x08000000);
+        assert!(val.is_pll_output_unmasked());
+
+        val = val.mask_pll_output();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_pll_output_unmasked());
+
+        val = val.set_pll_n(0xFF);
+        assert_eq!(val.0, 0x0000FF00);
+        assert_eq!(val.pll_n(), 0xFF);
+
+        val = val.set_pll_n(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.pll_n(), 0x0);
+
+        val = val.set_pll_m1(0x01);
+        assert_eq!(val.0, 0x00000002);
+        assert_eq!(val.pll_m1(), 0x01);
+
+        val = val.set_pll_m1(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.pll_m1(), 0x0);
+
+        val = val.set_pll_m0(0x01);
+        assert_eq!(val.0, 0x00000001);
+        assert_eq!(val.pll_m0(), 0x01);
+
+        val = val.set_pll_m0(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.pll_m0(), 0x0);
+    }
+
+    #[test]
+    fn struct_pll_peri0_control_fuctions() {
+        let mut val = PllPeri0Control(0x0);
+
+        val = val.enable_pll();
+        assert_eq!(val.0, 0x80000000);
+        assert!(val.is_pll_enabled());
+
+        val = val.disable_pll();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_pll_enabled());
+
+        val = val.enable_pll_ldo();
+        assert_eq!(val.0, 0x40000000);
+        assert!(val.is_pll_ldo_enabled());
+
+        val = val.disable_pll_ldo();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_pll_ldo_enabled());
+
+        val = val.enable_lock();
+        assert_eq!(val.0, 0x20000000);
+        assert!(val.is_lock_enabled());
+
+        val = val.disable_lock();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_lock_enabled());
+
+        let val = PllPeri0Control(0x10000000);
+        assert!(val.is_locked());
+        let val = PllPeri0Control(0x0);
+        assert!(!val.is_locked());
+
+        let mut val = PllPeri0Control(0x0);
+
+        val = val.unmask_pll_output();
+        assert_eq!(val.0, 0x08000000);
+        assert!(val.is_pll_output_unmasked());
+
+        val = val.mask_pll_output();
+        assert_eq!(val.0, 0x00000000);
+        assert!(!val.is_pll_output_unmasked());
+
+        val = val.set_pll_p1(0x07);
+        assert_eq!(val.0, 0x00700000);
+        assert_eq!(val.pll_p1(), 0x07);
+
+        val = val.set_pll_p1(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.pll_p1(), 0x0);
+
+        val = val.set_pll_p0(0x07);
+        assert_eq!(val.0, 0x00070000);
+        assert_eq!(val.pll_p0(), 0x07);
+
+        val = val.set_pll_p0(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.pll_p0(), 0x0);
+
+        val = val.set_pll_n(0xFF);
+        assert_eq!(val.0, 0x0000FF00);
+        assert_eq!(val.pll_n(), 0xFF);
+
+        val = val.set_pll_n(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.pll_n(), 0x0);
+
+        val = val.set_pll_m(0x01);
+        assert_eq!(val.0, 0x00000002);
+        assert_eq!(val.pll_m(), 0x01);
+
+        val = val.set_pll_m(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.pll_m(), 0x0);
+    }
+
+    #[test]
+    fn struct_cpu_axi_config_fuctions() {
+        let mut val = CpuAxiConfig(0x0);
+
+        for i in 0..7 as u8 {
+            let tmp = match i {
+                0 => CpuClockSource::Osc24M,
+                1 => CpuClockSource::Clk32K,
+                2 => CpuClockSource::Clk16MRC,
+                3 => CpuClockSource::PllCpu,
+                4 => CpuClockSource::PllPeri1x,
+                5 => CpuClockSource::PllPeri2x,
+                6 => CpuClockSource::PllPeri800M,
+                _ => panic!("impossible clock source"),
+            };
+
+            val = val.set_clock_source(tmp);
+
+            match i {
+                0 => assert_eq!(val.0, 0x00000000),
+                1 => assert_eq!(val.0, 0x01000000),
+                2 => assert_eq!(val.0, 0x02000000),
+                3 => assert_eq!(val.0, 0x03000000),
+                4 => assert_eq!(val.0, 0x04000000),
+                5 => assert_eq!(val.0, 0x05000000),
+                6 => assert_eq!(val.0, 0x06000000),
+                _ => panic!("impossible clock source"),
+            }
+
+            assert_eq!(val.clock_source(), tmp);
+        }
+
+        val = val.set_clock_source(CpuClockSource::Osc24M);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.clock_source(), CpuClockSource::Osc24M);
+
+        for i in 0..3 as u8 {
+            let tmp = match i {
+                0 => FactorP::P1,
+                1 => FactorP::P2,
+                2 => FactorP::P4,
+                _ => unreachable!(),
+            };
+
+            val = val.set_factor_p(tmp);
+
+            match i {
+                0 => assert_eq!(val.0, 0x00000000),
+                1 => assert_eq!(val.0, 0x00010000),
+                2 => assert_eq!(val.0, 0x00020000),
+                _ => unreachable!(),
+            }
+
+            assert_eq!(val.factor_p(), tmp);
+        }
+
+        val = val.set_factor_p(FactorP::P1);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.factor_p(), FactorP::P1);
+
+        val = val.set_factor_n(0x03);
+        assert_eq!(val.0, 0x00000300);
+        assert_eq!(val.factor_n(), 0x03);
+
+        val = val.set_factor_n(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.factor_n(), 0x0);
+
+        val = val.set_factor_m(0x03);
+        assert_eq!(val.0, 0x00000003);
+        assert_eq!(val.factor_m(), 0x03);
+
+        val = val.set_factor_m(0x0);
+        assert_eq!(val.0, 0x00000000);
+        assert_eq!(val.factor_m(), 0x0);
+    }
+
     // TODO structure read/write function unit tests.
     // Please refer to this link while implementing: https://github.com/rustsbi/bouffalo-hal/blob/6ee8ebf5fde184a68f4c3d5a1b7838dbbc7bfdd3/bouffalo-hal/src/i2c.rs#L902
-    // TODO #[test] fn struct_cpu_axi_config_functions()
     // TODO struct_mbus_clock_functions
     // TODO struct_dram_clock_functions
     // TODO struct_dram_bgr_functions

--- a/src/smhc.rs
+++ b/src/smhc.rs
@@ -7,31 +7,33 @@ pub struct RegisterBlock {
     /// 0x04 - SMC Clock Control Register.
     pub clock_control: RW<ClockControl>,
     /// 0x08 - SMC Time Out Register.
-    pub timeout: RW<u32>,
+    pub timeout: RW<TimeOut>,
     /// 0x0C - SMC Bus Width Register.
-    pub bus_width: RW<u32>,
+    pub bus_width: RW<BusWidth>,
     /// 0x10 - SMC Block Size Register.
-    pub block_size: RW<u32>,
+    pub block_size: RW<BlockSize>,
     /// 0x14 - SMC Byte Count Register.
-    pub byte_count: RW<u32>,
+    pub byte_count: RW<ByteCount>,
     /// 0x18 - SMC Command Register.
-    pub command: RW<u32>,
+    pub command: RW<Command>,
     /// 0x1C - SMC Argument Register.
-    pub argument: RW<u32>,
+    pub argument: RW<Argument>,
     /// 0x20 ..= 0x2C - SMC Response Registers 0..=3.
     pub responses: [RO<u32>; 4],
     /// 0x30 - SMC Interrupt Mask Register.
-    pub interrupt_mask: RW<u32>,
+    pub interrupt_mask: RW<InterruptMask>,
     /// 0x34 - SMC Masked Interrupt Status Register.
-    pub interrupt_state_masked: RO<u32>,
+    pub interrupt_state_masked: RO<InterruptStateMasked>,
     /// 0x38 - SMC Raw Interrupt Status Register.
-    pub interrupt_state_raw: RW<u32>,
+    pub interrupt_state_raw: RW<InterruptStateRaw>,
     /// 0x3C - SMC Status Register.
-    pub status: RO<u32>,
-    /// 0x40 - SMC FIFO Threshold Watermark Register.
-    pub fifo_threshold: RW<u32>,
+    pub status: RO<Status>,
+    /// 0x40 - SMC FIFO Water Level Register.
+    pub fifo_water_level: RW<FifoWaterLevel>,
+    _reserved0: [u32; 6],
     /// 0x5c - SMC New Timing Set Register.
-    pub new_timing_set: RW<u32>,
+    pub new_timing_set: RW<NewTimingSet>,
+    _reserved1: [u32; 8],
     /// 0x80 - SMC IDMAC Control Register.
     pub dma_control: RW<u32>,
     /// 0x84 - SMC IDMAC Descriptor List Base Address Register.
@@ -40,10 +42,13 @@ pub struct RegisterBlock {
     pub dma_state: RW<u32>,
     /// 0x8C - SMC IDMAC Interrupt Enable Register.
     pub dma_interrupt_enable: RW<u32>,
+    _reserved2: [u32; 44],
     /// 0x140 - Drive Delay Control register.
-    pub drive_delay_control: RW<u32>,
+    pub drive_delay_control: RW<DriveDelayControl>,
+    _reserved3: [u32; 16],
     /// 0x184 - deskew control control register.
     pub skew_control: RW<u32>,
+    _reserved4: [u32; 30],
     /// 0x200 - SMC FIFO Access Address.
     pub fifo: RW<u32>,
 }
@@ -53,15 +58,118 @@ pub struct RegisterBlock {
 #[repr(transparent)]
 pub struct GlobalControl(u32);
 
+/// FIFO access mode
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AccessMode {
+    // Dma bus
+    Dma,
+    // Ahb bus
+    Ahb,
+}
+
+/// DDR mode
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DdrMode {
+    // SDR mode
+    Sdr,
+    // DDR mode
+    Ddr,
+}
+
 impl GlobalControl {
-    // TODO access_mode, set_access_mode, enum AccessMode { Dma, Ahb }
-    // TODO ddr_mode, set_ddr_mode, enum DdrMode { Sdr, Ddr }
-    // TODO is_dma_enabled, enable_dma, disable_dma
-    // TODO is_interrupt_enabled, enable_interrupt, disable_interrupt
+    const FIFO_AC_MOD: u32 = 1 << 31;
+    const DDR_MOD: u32 = 1 << 10;
+    const DMA_ENB: u32 = 1 << 5;
+    const INT_ENB: u32 = 1 << 4;
+    const DMA_RST: u32 = 1 << 2;
+    const FIFO_RST: u32 = 1 << 1;
+    const SOFT_RST: u32 = 1 << 0;
+
+    /// Get FIFO access mode.
+    #[inline]
+    pub const fn access_mode(self) -> AccessMode {
+        match (self.0 & Self::FIFO_AC_MOD) >> 31 {
+            0 => AccessMode::Dma,
+            1 => AccessMode::Ahb,
+            _ => unreachable!(),
+        }
+    }
+    /// Set FIFO access mode.
+    #[inline]
+    pub const fn set_access_mode(self, mode: AccessMode) -> Self {
+        let mode = match mode {
+            AccessMode::Dma => 0x0,
+            AccessMode::Ahb => 0x1,
+        };
+        Self((self.0 & !Self::FIFO_AC_MOD) | (mode << 31))
+    }
+    /// Get DDR mode.
+    #[inline]
+    pub const fn ddr_mode(self) -> DdrMode {
+        match (self.0 & Self::DDR_MOD) >> 10 {
+            0x0 => DdrMode::Sdr,
+            0x1 => DdrMode::Ddr,
+            _ => unreachable!(),
+        }
+    }
+    /// Set DDR mode.
+    #[inline]
+    pub const fn set_ddr_mode(self, mode: DdrMode) -> Self {
+        let mode = match mode {
+            DdrMode::Sdr => 0x0,
+            DdrMode::Ddr => 0x1,
+        };
+        Self((self.0 & !Self::DDR_MOD) | (mode << 10))
+    }
+    /// Is DMA enabled?
+    #[inline]
+    pub const fn is_dma_enabled(self) -> bool {
+        self.0 & Self::DMA_ENB != 0
+    }
+    /// Enable DMA.
+    #[inline]
+    pub const fn enable_dma(self) -> Self {
+        Self(self.0 | Self::DMA_ENB)
+    }
+    /// Disable DMA.
+    #[inline]
+    pub const fn disable_dma(self) -> Self {
+        Self(self.0 & !Self::DMA_ENB)
+    }
+    /// Is interrupt enabled?
+    #[inline]
+    pub const fn is_interrupt_enabled(self) -> bool {
+        self.0 & Self::INT_ENB != 0
+    }
+    /// Enable interrupt.
+    #[inline]
+    pub const fn enable_interrupt(self) -> Self {
+        Self(self.0 | Self::INT_ENB)
+    }
+    /// Disable interrupt.
+    #[inline]
+    pub const fn disable_interrupt(self) -> Self {
+        Self(self.0 & !Self::INT_ENB)
+    }
+    /// DMA Reset.
+    #[inline]
+    pub const fn set_dma_reset(self) -> Self {
+        Self(self.0 | Self::DMA_RST)
+    }
+    /// FIFO Reset.
+    #[inline]
+    pub const fn set_fifo_reset(self) -> Self {
+        Self(self.0 | Self::FIFO_RST)
+    }
+    /// Software Reset.
+    #[inline]
+    pub const fn set_software_reset(self) -> Self {
+        Self(self.0 | Self::SOFT_RST)
+    }
     // note: DMA_RST, FIFO_RST and SOFT_RST are write-1-set, auto-cleared by hardware
-    // TODO has_dma_reset (DMA_RST == 1), set_dma_reset (self.0 | DMA_RST)
-    // TODO has_fifo_reset, set_fifo_reset
-    // TODO has_software_reset, set_software_reset
+    // TODO has_dma_reset
+    // TODO has_fifo_reset
+    // TODO has_software_reset
 }
 
 /// Clock control register.
@@ -70,62 +178,367 @@ impl GlobalControl {
 pub struct ClockControl(u32);
 
 impl ClockControl {
-    // TODO is_mask_data0_enabled, enable_mask_data0, disable_mask_data0
-    // TODO is_card_clock_enabled, enable_card_clock, disable_card_clock
-    // TODO card_clock_divider, set_card_clock_divider (u8)
+    const MASK_DATA0: u32 = 1 << 31;
+    const CCLK_CTRL: u32 = 1 << 17;
+    const CCLK_DIV: u32 = 0xFF << 0;
+    /// If mask data0 is enabled.
+    #[inline]
+    pub const fn is_mask_data0_enabled(self) -> bool {
+        self.0 & Self::MASK_DATA0 != 0
+    }
+    /// Enable mask data0.
+    #[inline]
+    pub const fn enable_mask_data0(self) -> Self {
+        Self(self.0 | Self::MASK_DATA0)
+    }
+    /// Disable mask data0.
+    #[inline]
+    pub const fn disable_mask_data0(self) -> Self {
+        Self(self.0 & !Self::MASK_DATA0)
+    }
+    /// If card clock is enabled.
+    pub const fn is_card_clock_enabled(self) -> bool {
+        self.0 & Self::CCLK_CTRL != 0
+    }
+    /// Enable card clock.
+    #[inline]
+    pub const fn enable_card_clock(self) -> Self {
+        Self(self.0 | Self::CCLK_CTRL)
+    }
+    /// Disable card clock.
+    #[inline]
+    pub const fn disable_card_clock(self) -> Self {
+        Self(self.0 & !Self::CCLK_CTRL)
+    }
+    /// Get card clock divider.
+    #[inline]
+    pub const fn card_clock_divider(self) -> u8 {
+        ((self.0 & Self::CCLK_DIV) >> 0) as u8
+    }
+    /// Set card clock divider.
+    #[inline]
+    pub const fn set_card_clock_divider(self, divider: u8) -> Self {
+        Self((self.0 & !Self::CCLK_DIV) | ((divider as u32) << 0))
+    }
 }
 
-// TODO pub struct Timeout
+/// Time out register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct TimeOut(u32);
 
-// TODO data_timeout_limit, set_data_timeout_limit (u32)
+impl TimeOut {
+    const DTO_LMT: u32 = 0xFFFFFF << 8;
 
-// TODO pub struct BusWidth
+    /// Get data timeout limit.
+    #[inline]
+    pub const fn data_timeout_limit(self) -> u32 {
+        (self.0 & Self::DTO_LMT) >> 8
+    }
+    /// Set data timeout limit.
+    #[inline]
+    pub const fn set_data_timeout_limit(self, limit: u32) -> Self {
+        Self((self.0 & !Self::DTO_LMT) | (limit << 8))
+    }
+}
 
-// TODO bus_width, set_bus_width, enum BusWidth { OneBit, FourBit, EightBit }
+/// Bus width register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct BusWidth(u32);
 
-// TODO pub struct BlockSize
+/// busWidth
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Bus_Width {
+    /// 1 bit
+    OneBit,
+    /// 4 bit
+    FourBit,
+    /// 8 bit
+    EightBit,
+}
 
-// TODO block_size, set_block_size (u16)
+impl BusWidth {
+    const CARD_WID: u32 = 0x3 << 0;
+    /// Get bus width.
+    #[inline]
+    pub const fn bus_width(self) -> Bus_Width {
+        match (self.0 & Self::CARD_WID) >> 0 {
+            0x0 => Bus_Width::OneBit,
+            0x1 => Bus_Width::FourBit,
+            0x2 | 0x3 => Bus_Width::EightBit,
+            _ => unreachable!(),
+        }
+    }
+    /// Set bus width.
+    #[inline]
+    pub const fn set_bus_width(self, width: Bus_Width) -> Self {
+        Self((self.0 & !Self::CARD_WID) | ((width as u32) << 0))
+    }
+}
 
-// TODO pub struct ByteCount
+/// Block size register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct BlockSize(u32);
 
-// TODO byte_count, set_byte_count (u32)
+impl BlockSize {
+    const BLK_SZ: u32 = 0x0000FFFF << 0;
+    /// Get block size.
+    #[inline]
+    pub const fn block_size(self) -> u16 {
+        ((self.0 & Self::BLK_SZ) >> 0) as u16
+    }
+    /// Set block size.
+    #[inline]
+    pub const fn set_block_size(self, size: u16) -> Self {
+        Self((self.0 & !Self::BLK_SZ) | ((size as u32) << 0))
+    }
+}
 
-// TODO pub struct Command
+/// Byte count register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct ByteCount(u32);
 
-// bit 31 (SMHC_CMD_START, or CMD_LOAD) is write-1-set by software, auto-cleared by hardware
-// TODO has_command_start, set_command_start
-// bit 21 (SMHC_CMD_UPCLK_ONLY or PRG_CLK)
-// TODO is_change_clock_enabled, enable_change_clock, disable_change_clock
-// bit 15 (SMHC_CMD_SEND_INIT_SEQUENCE or SEND_INIT_SEQ)
-// TODO is_init_sequence_enabled, enable_init_sequence, disable_init_sequence
-// bit 14 (SMHC_CMD_STOP_ABORT_CMD or STOP_ABT_CMD)
-// TODO is_stop_abort_enabled, enable_stop_abort, disable_stop_abort
-// bit 13 (SMHC_CMD_WAIT_PRE_OVER, WAIT_PRE_OVER)
-// TODO is_wait_for_complete_enabled, enable_wait_for_complete, disable_wait_for_complete
-// bit 12 (SMHC_CMD_SEND_AUTO_STOP, STOP_CMD_FLAG)
-// TODO is_auto_stop_enabled, enable_auto_stop, disable_auto_stop
-// bit 10 (SMHC_CMD_WRITE or TRANS_DIR)
-// TODO transfer_direction, set_transfer_direction, enum TransferDirection { Read, Write }
-// bit 9 (SMHC_CMD_DATA_EXPIRE or DATA_TRANS)
-// TODO is_data_transfer_enabled, enable_data_transfer, disable_data_transfer
-// bit 8 (SMHC_CMD_CHECK_RESPONSE_CRC, CHK_RESP_CRC)
-// TODO is_check_response_crc_enabled, enable_check_response_crc, disable_check_response_crc
-// bit 7 (SMHC_CMD_LONG_RESPONSE or LONG_RESP)
-// TODO is_long_response_enabled, enable_long_response, disable_long_response
-// bit 6 (SMHC_CMD_RESP_EXPIRE, or RESP_RCV)
-// TODO is_response_receive_enabled, enable_response_receive, disable_response_receive
-// bit 5:0 CMD_IDX
-// TODO command_index, set_command_index (u8)
+impl ByteCount {
+    const BYTE_CNT: u32 = 0xFFFFFFFF << 0;
+    /// Get byte count.
+    #[inline]
+    pub const fn byte_count(self) -> u32 {
+        (self.0 & Self::BYTE_CNT) >> 0
+    }
+    /// Set byte count.
+    #[inline]
+    pub const fn set_byte_count(self, count: u32) -> Self {
+        Self((self.0 & !Self::BYTE_CNT) | (count << 0))
+    }
+}
 
-// TODO pub struct Argument
+/// Command register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct Command(u32);
 
-// TODO argument, set_argument (u32)
+/// busWidth
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TransferDirection {
+    /// Read from card
+    Read,
+    /// Write to card
+    Write,
+}
 
-// TODO pub struct InterruptEnable
+impl Command {
+    const CMD_LOAD: u32 = 0x1 << 31;
+    const PRG_CLK: u32 = 0x1 << 21;
+    const SEND_INIT_SEQ: u32 = 0x1 << 15;
+    const STOP_ABT_CMD: u32 = 0x1 << 14;
+    const WAIT_PRE_OVER: u32 = 0x1 << 13;
+    const STOP_CMD_FLAG: u32 = 0x1 << 12;
+    const TRANS_DIR: u32 = 0x1 << 10;
+    const DATA_TRANS: u32 = 0x1 << 9;
+    const CHK_RESP_CRC: u32 = 0x1 << 8;
+    const LONG_RESP: u32 = 0x1 << 7;
+    const RESP_RCV: u32 = 0x1 << 6;
+    const CMD_IDX: u32 = 0x3F << 0;
 
-// TODO is_interrupt_unmasked, mask_interrupt, unmask_interrupt (Interrupt)
-/* TODO pub enum Interrupt {
+    /// Start command.
+    #[inline]
+    pub const fn set_command_start(self) -> Self {
+        Self(self.0 | Self::CMD_LOAD)
+    }
+    ///If change clock is enabled.
+    #[inline]
+    pub const fn is_change_clock_enabled(self) -> bool {
+        (self.0 & Self::PRG_CLK) != 0
+    }
+    /// Enable change clock.
+    #[inline]
+    pub const fn enable_change_clock(self) -> Self {
+        Self(self.0 | Self::PRG_CLK)
+    }
+    /// Disable change clock.
+    #[inline]
+    pub const fn disable_change_clock(self) -> Self {
+        Self(self.0 & !Self::PRG_CLK)
+    }
+    /// If send init sequence is enabled.
+    #[inline]
+    pub const fn is_send_init_seq_enabled(self) -> bool {
+        (self.0 & Self::SEND_INIT_SEQ) != 0
+    }
+    /// Enable send init sequence.
+    #[inline]
+    pub const fn enable_send_init_seq(self) -> Self {
+        Self(self.0 | Self::SEND_INIT_SEQ)
+    }
+    /// Disable send init sequence.
+    #[inline]
+    pub const fn disable_send_init_seq(self) -> Self {
+        Self(self.0 & !Self::SEND_INIT_SEQ)
+    }
+    /// if stop abort command is enabled.
+    #[inline]
+    pub const fn is_stop_abort_enabled(self) -> bool {
+        (self.0 & Self::STOP_ABT_CMD) != 0
+    }
+    /// Enable stop abort command.
+    #[inline]
+    pub const fn enable_stop_abort(self) -> Self {
+        Self(self.0 | Self::STOP_ABT_CMD)
+    }
+    /// Disable stop abort command.
+    #[inline]
+    pub const fn disable_stop_abort(self) -> Self {
+        Self(self.0 & !Self::STOP_ABT_CMD)
+    }
+    /// If wait for complete is enabled.
+    #[inline]
+    pub const fn is_wait_for_complete_enabled(self) -> bool {
+        (self.0 & Self::WAIT_PRE_OVER) != 0
+    }
+    /// Enable wait for complete.
+    #[inline]
+    pub const fn enable_wait_for_complete(self) -> Self {
+        Self(self.0 | Self::WAIT_PRE_OVER)
+    }
+    /// Disable wait for complete.
+    #[inline]
+    pub const fn disable_wait_for_complete(self) -> Self {
+        Self(self.0 & !Self::WAIT_PRE_OVER)
+    }
+    /// If auto stop is enabled.
+    #[inline]
+    pub const fn is_auto_stop_enabled(self) -> bool {
+        (self.0 & Self::STOP_CMD_FLAG) != 0
+    }
+    /// Enable auto stop.
+    #[inline]
+    pub const fn enable_auto_stop(self) -> Self {
+        Self(self.0 | Self::STOP_CMD_FLAG)
+    }
+    /// Disable auto stop.
+    #[inline]
+    pub const fn disable_auto_stop(self) -> Self {
+        Self(self.0 & !Self::STOP_CMD_FLAG)
+    }
+    /// Get transfer direction.
+    #[inline]
+    pub const fn transfer_direction(self) -> TransferDirection {
+        match (self.0 & Self::TRANS_DIR) >> 10 {
+            0 => TransferDirection::Read,
+            1 => TransferDirection::Write,
+            _ => unreachable!(),
+        }
+    }
+    /// Set transfer direction.
+    #[inline]
+    pub const fn set_transfer_direction(self, dir: TransferDirection) -> Self {
+        Self((self.0 & !Self::TRANS_DIR) | ((dir as u32) << 10))
+    }
+    /// If data transfer is enabled.
+    #[inline]
+    pub const fn is_data_transfer_enabled(self) -> bool {
+        (self.0 & Self::DATA_TRANS) != 0
+    }
+    /// Enable data transfer.
+    #[inline]
+    pub const fn enable_data_transfer(self) -> Self {
+        Self(self.0 | Self::DATA_TRANS)
+    }
+    /// Disable data transfer.
+    #[inline]
+    pub const fn disable_data_transfer(self) -> Self {
+        Self(self.0 & !Self::DATA_TRANS)
+    }
+    /// If check response CRC is enabled.
+    #[inline]
+    pub const fn is_check_response_crc_enabled(self) -> bool {
+        (self.0 & Self::CHK_RESP_CRC) != 0
+    }
+    /// Enable check response CRC.
+    #[inline]
+    pub const fn enable_check_response_crc(self) -> Self {
+        Self(self.0 | Self::CHK_RESP_CRC)
+    }
+    /// Disable check response CRC.
+    #[inline]
+    pub const fn disable_check_response_crc(self) -> Self {
+        Self(self.0 & !Self::CHK_RESP_CRC)
+    }
+    /// If long response is enabled.
+    #[inline]
+    pub const fn is_long_response_enabled(self) -> bool {
+        (self.0 & Self::LONG_RESP) != 0
+    }
+    /// Enable long response.
+    #[inline]
+    pub const fn enable_long_response(self) -> Self {
+        Self(self.0 | Self::LONG_RESP)
+    }
+    /// Disable long response.
+    #[inline]
+    pub const fn disable_long_response(self) -> Self {
+        Self(self.0 & !Self::LONG_RESP)
+    }
+    /// If response receive enabled.
+    #[inline]
+    pub const fn is_response_receive_enabled(self) -> bool {
+        (self.0 & Self::RESP_RCV) != 0
+    }
+    /// Enable response receive.
+    #[inline]
+    pub const fn enable_response_receive(self) -> Self {
+        Self(self.0 | Self::RESP_RCV)
+    }
+    /// Disable response receive.
+    #[inline]
+    pub const fn disable_response_receive(self) -> Self {
+        Self(self.0 & !Self::RESP_RCV)
+    }
+    /// Get command index.
+    #[inline]
+    pub const fn command_index(self) -> u8 {
+        ((self.0 & Self::CMD_IDX) >> 0) as u8
+    }
+    /// Set command index.
+    #[inline]
+    pub const fn set_command_index(self, val: u8) -> Self {
+        Self((self.0 & !Self::CMD_IDX) | ((val as u32) << 0))
+    }
+    // bit 31 (SMHC_CMD_START, or CMD_LOAD) is write-1-set by software, auto-cleared by hardware
+    // TODO has_command_start
+}
+
+/// Argument register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct Argument(u32);
+
+impl Argument {
+    const CMD_ARG: u32 = 0xFFFFFFFF << 0;
+
+    /// Get argument
+    #[inline]
+    pub fn argument(self) -> u32 {
+        (self.0 & Self::CMD_ARG) as u32 >> 0
+    }
+    /// Set argument
+    #[inline]
+    pub fn set_argument(self, arg: u32) -> Self {
+        Self((self.0 & !Self::CMD_ARG) | ((arg as u32) << 0))
+    }
+}
+
+/// Interrupt mask register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct InterruptMask(u32);
+
+/// interrupt
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Interrupt {
     CardRemoved,
     CardInserted,
     Sdio,
@@ -143,41 +556,960 @@ impl ClockControl {
     DataTransmitRequest,
     DataTransferComplete,
     CommandComplete,
-    ResponseError
-} */
+    ResponseError,
+}
 
-// TODO pub struct InterruptStateMasked
+impl InterruptMask {
+    const CARD_REMOVAL_INT_EN: u32 = 1 << 31;
+    const CARD_INSERT_INT_EN: u32 = 1 << 30;
+    const SDIO_INT_EN: u32 = 1 << 16;
+    const DEE_INT_EN: u32 = 1 << 15;
+    const ACD_INT_EN: u32 = 1 << 14;
+    const DSE_BC_INT_EN: u32 = 1 << 13;
+    const CB_IW_INT_EN: u32 = 1 << 12;
+    const FU_FO_INT_EN: u32 = 1 << 11;
+    const DSTO_VSD_INT_EN: u32 = 1 << 10;
+    const DTO_BDS_INT_EN: u32 = 1 << 9;
+    const RTO_BACK_INT_EN: u32 = 1 << 8;
+    const DCE_INT_EN: u32 = 1 << 7;
+    const RCE_INT_EN: u32 = 1 << 6;
+    const DRR_INT_EN: u32 = 1 << 5;
+    const DTR_INT_EN: u32 = 1 << 4;
+    const DTC_INT_EN: u32 = 1 << 3;
+    const CC_INT_EN: u32 = 1 << 2;
+    const RE_INT_EN: u32 = 1 << 1;
 
-// TODO has_interrupt (Interrupt)
+    /// If the interrupt is masked.
+    pub fn is_interrupt_masked(self, interrupt: Interrupt) -> bool {
+        match interrupt {
+            Interrupt::CardRemoved => self.0 & Self::CARD_REMOVAL_INT_EN != 0,
+            Interrupt::CardInserted => self.0 & Self::CARD_INSERT_INT_EN != 0,
+            Interrupt::Sdio => self.0 & Self::SDIO_INT_EN != 0,
+            Interrupt::DataEndBitError => self.0 & Self::DEE_INT_EN != 0,
+            Interrupt::AutoCommandDone => self.0 & Self::ACD_INT_EN != 0,
+            Interrupt::DataStartError => self.0 & Self::DSE_BC_INT_EN != 0,
+            Interrupt::CommandBusyAndIllegalWrite => self.0 & Self::CB_IW_INT_EN != 0,
+            Interrupt::FifoUnderrunOrOverflow => self.0 & Self::FU_FO_INT_EN != 0,
+            Interrupt::DataStarvationTimeout1V8SwitchDone => self.0 & Self::DSTO_VSD_INT_EN != 0,
+            Interrupt::DataTimeoutBootDataStart => self.0 & Self::DTO_BDS_INT_EN != 0,
+            Interrupt::ResponseTimeoutBootAckReceived => self.0 & Self::RTO_BACK_INT_EN != 0,
+            Interrupt::DataCrcError => self.0 & Self::DCE_INT_EN != 0,
+            Interrupt::ResponseCrcError => self.0 & Self::RCE_INT_EN != 0,
+            Interrupt::DataReceiveRequest => self.0 & Self::DRR_INT_EN != 0,
+            Interrupt::DataTransmitRequest => self.0 & Self::DTR_INT_EN != 0,
+            Interrupt::DataTransferComplete => self.0 & Self::DTC_INT_EN != 0,
+            Interrupt::CommandComplete => self.0 & Self::CC_INT_EN != 0,
+            Interrupt::ResponseError => self.0 & Self::RE_INT_EN != 0,
+        }
+    }
+    /// Mask the specified interrupt.
+    #[inline]
+    pub fn mask_interrupt(self, interrupt: Interrupt) -> Self {
+        match interrupt {
+            Interrupt::CardRemoved => Self(self.0 | Self::CARD_REMOVAL_INT_EN),
+            Interrupt::CardInserted => Self(self.0 | Self::CARD_INSERT_INT_EN),
+            Interrupt::Sdio => Self(self.0 | Self::SDIO_INT_EN),
+            Interrupt::DataEndBitError => Self(self.0 | Self::DEE_INT_EN),
+            Interrupt::AutoCommandDone => Self(self.0 | Self::ACD_INT_EN),
+            Interrupt::DataStartError => Self(self.0 | Self::DSE_BC_INT_EN),
+            Interrupt::CommandBusyAndIllegalWrite => Self(self.0 | Self::CB_IW_INT_EN),
+            Interrupt::FifoUnderrunOrOverflow => Self(self.0 | Self::FU_FO_INT_EN),
+            Interrupt::DataStarvationTimeout1V8SwitchDone => Self(self.0 | Self::DSTO_VSD_INT_EN),
+            Interrupt::DataTimeoutBootDataStart => Self(self.0 | Self::DTO_BDS_INT_EN),
+            Interrupt::ResponseTimeoutBootAckReceived => Self(self.0 | Self::RTO_BACK_INT_EN),
+            Interrupt::DataCrcError => Self(self.0 | Self::DCE_INT_EN),
+            Interrupt::ResponseCrcError => Self(self.0 | Self::RCE_INT_EN),
+            Interrupt::DataReceiveRequest => Self(self.0 | Self::DRR_INT_EN),
+            Interrupt::DataTransmitRequest => Self(self.0 | Self::DTR_INT_EN),
+            Interrupt::DataTransferComplete => Self(self.0 | Self::DTC_INT_EN),
+            Interrupt::CommandComplete => Self(self.0 | Self::CC_INT_EN),
+            Interrupt::ResponseError => Self(self.0 | Self::RE_INT_EN),
+        }
+    }
+    /// Unmask the specified interrupt.
+    #[inline]
+    pub fn unmask_interrupt(self, interrupt: Interrupt) -> Self {
+        match interrupt {
+            Interrupt::CardRemoved => Self(self.0 & !Self::CARD_REMOVAL_INT_EN),
+            Interrupt::CardInserted => Self(self.0 & !Self::CARD_INSERT_INT_EN),
+            Interrupt::Sdio => Self(self.0 & !Self::SDIO_INT_EN),
+            Interrupt::DataEndBitError => Self(self.0 & !Self::DEE_INT_EN),
+            Interrupt::AutoCommandDone => Self(self.0 & !Self::ACD_INT_EN),
+            Interrupt::DataStartError => Self(self.0 & !Self::DSE_BC_INT_EN),
+            Interrupt::CommandBusyAndIllegalWrite => Self(self.0 & !Self::CB_IW_INT_EN),
+            Interrupt::FifoUnderrunOrOverflow => Self(self.0 & !Self::FU_FO_INT_EN),
+            Interrupt::DataStarvationTimeout1V8SwitchDone => Self(self.0 & !Self::DSTO_VSD_INT_EN),
+            Interrupt::DataTimeoutBootDataStart => Self(self.0 & !Self::DTO_BDS_INT_EN),
+            Interrupt::ResponseTimeoutBootAckReceived => Self(self.0 & !Self::RTO_BACK_INT_EN),
+            Interrupt::DataCrcError => Self(self.0 & !Self::DCE_INT_EN),
+            Interrupt::ResponseCrcError => Self(self.0 & !Self::RCE_INT_EN),
+            Interrupt::DataReceiveRequest => Self(self.0 & !Self::DRR_INT_EN),
+            Interrupt::DataTransmitRequest => Self(self.0 & !Self::DTR_INT_EN),
+            Interrupt::DataTransferComplete => Self(self.0 & !Self::DTC_INT_EN),
+            Interrupt::CommandComplete => Self(self.0 & !Self::CC_INT_EN),
+            Interrupt::ResponseError => Self(self.0 & !Self::RE_INT_EN),
+        }
+    }
+}
 
-// TODO pub struct InterruptStateRaw
+/// Masked Interrupt state masked register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct InterruptStateMasked(u32);
 
-// TODO has_raw_interrupt (Interrupt)
-// TODO clear_interrupt (Interrupt) note: write 1 to clear
+impl InterruptStateMasked {
+    const M_CARD_REMOVAL_INT: u32 = 1 << 31;
+    const M_CARD_INSERT_INT: u32 = 1 << 30;
+    const M_SDIO_INT: u32 = 1 << 16;
+    const M_DEE_INT: u32 = 1 << 15;
+    const M_ACD_INT: u32 = 1 << 14;
+    const M_DSE_BC_INT: u32 = 1 << 13;
+    const M_CB_IW_INT_: u32 = 1 << 12;
+    const M_FU_FO_INT: u32 = 1 << 11;
+    const M_DSTO_VSD_INT: u32 = 1 << 10;
+    const M_DTO_BDS_INT: u32 = 1 << 9;
+    const M_RTO_BACK_INT: u32 = 1 << 8;
+    const M_DCE_INT: u32 = 1 << 7;
+    const M_RCE_INT: u32 = 1 << 6;
+    const M_DRR_INT: u32 = 1 << 5;
+    const M_DTR_INT: u32 = 1 << 4;
+    const M_DTC_INT: u32 = 1 << 3;
+    const M_CC_INT: u32 = 1 << 2;
+    const M_RE_INT: u32 = 1 << 1;
 
-// TODO pub struct Status
+    /// If the interrupt occurs.
+    #[inline]
+    pub fn has_interrupt(self, interrupt: Interrupt) -> bool {
+        match interrupt {
+            Interrupt::CardRemoved => self.0 & Self::M_CARD_REMOVAL_INT != 0,
+            Interrupt::CardInserted => self.0 & Self::M_CARD_INSERT_INT != 0,
+            Interrupt::Sdio => self.0 & Self::M_SDIO_INT != 0,
+            Interrupt::DataEndBitError => self.0 & Self::M_DEE_INT != 0,
+            Interrupt::AutoCommandDone => self.0 & Self::M_ACD_INT != 0,
+            Interrupt::DataStartError => self.0 & Self::M_DSE_BC_INT != 0,
+            Interrupt::CommandBusyAndIllegalWrite => self.0 & Self::M_CB_IW_INT_ != 0,
+            Interrupt::FifoUnderrunOrOverflow => self.0 & Self::M_FU_FO_INT != 0,
+            Interrupt::DataStarvationTimeout1V8SwitchDone => self.0 & Self::M_DSTO_VSD_INT != 0,
+            Interrupt::DataTimeoutBootDataStart => self.0 & Self::M_DTO_BDS_INT != 0,
+            Interrupt::ResponseTimeoutBootAckReceived => self.0 & Self::M_RTO_BACK_INT != 0,
+            Interrupt::DataCrcError => self.0 & Self::M_DCE_INT != 0,
+            Interrupt::ResponseCrcError => self.0 & Self::M_RCE_INT != 0,
+            Interrupt::DataReceiveRequest => self.0 & Self::M_DRR_INT != 0,
+            Interrupt::DataTransmitRequest => self.0 & Self::M_DTR_INT != 0,
+            Interrupt::DataTransferComplete => self.0 & Self::M_DTC_INT != 0,
+            Interrupt::CommandComplete => self.0 & Self::M_CC_INT != 0,
+            Interrupt::ResponseError => self.0 & Self::M_RE_INT != 0,
+        }
+    }
+}
 
+/// Raw Interrupt state register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct InterruptStateRaw(u32);
+
+impl InterruptStateRaw {
+    const CARD_REMOVAL: u32 = 1 << 31;
+    const CARD_INSERT: u32 = 1 << 30;
+    const SDIO_INT: u32 = 1 << 16;
+    const DEE: u32 = 1 << 15;
+    const ACD: u32 = 1 << 14;
+    const DSE_BC: u32 = 1 << 13;
+    const CB_IW: u32 = 1 << 12;
+    const FU_FO: u32 = 1 << 11;
+    const DSTO_VSD: u32 = 1 << 10;
+    const DTO_BDS: u32 = 1 << 9;
+    const RTO_BACK: u32 = 1 << 8;
+    const DCE: u32 = 1 << 7;
+    const RCE: u32 = 1 << 6;
+    const DRR: u32 = 1 << 5;
+    const DTR: u32 = 1 << 4;
+    const DTC: u32 = 1 << 3;
+    const CC: u32 = 1 << 2;
+    const RE: u32 = 1 << 1;
+
+    /// If the interrupt occurs.
+    #[inline]
+    pub fn has_interrupt(self, interrupt: Interrupt) -> bool {
+        match interrupt {
+            Interrupt::CardRemoved => self.0 & Self::CARD_REMOVAL != 0,
+            Interrupt::CardInserted => self.0 & Self::CARD_INSERT != 0,
+            Interrupt::Sdio => self.0 & Self::SDIO_INT != 0,
+            Interrupt::DataEndBitError => self.0 & Self::DEE != 0,
+            Interrupt::AutoCommandDone => self.0 & Self::ACD != 0,
+            Interrupt::DataStartError => self.0 & Self::DSE_BC != 0,
+            Interrupt::CommandBusyAndIllegalWrite => self.0 & Self::CB_IW != 0,
+            Interrupt::FifoUnderrunOrOverflow => self.0 & Self::FU_FO != 0,
+            Interrupt::DataStarvationTimeout1V8SwitchDone => self.0 & Self::DSTO_VSD != 0,
+            Interrupt::DataTimeoutBootDataStart => self.0 & Self::DTO_BDS != 0,
+            Interrupt::ResponseTimeoutBootAckReceived => self.0 & Self::RTO_BACK != 0,
+            Interrupt::DataCrcError => self.0 & Self::DCE != 0,
+            Interrupt::ResponseCrcError => self.0 & Self::RCE != 0,
+            Interrupt::DataReceiveRequest => self.0 & Self::DRR != 0,
+            Interrupt::DataTransmitRequest => self.0 & Self::DTR != 0,
+            Interrupt::DataTransferComplete => self.0 & Self::DTC != 0,
+            Interrupt::CommandComplete => self.0 & Self::CC != 0,
+            Interrupt::ResponseError => self.0 & Self::RE != 0,
+        }
+    }
+    /// Clears the specified interrupt.
+    #[inline]
+    pub fn clear_interrupt(self, interrupt: Interrupt) -> Self {
+        match interrupt {
+            Interrupt::CardRemoved => Self(self.0 | Self::CARD_REMOVAL),
+            Interrupt::CardInserted => Self(self.0 | Self::CARD_INSERT),
+            Interrupt::Sdio => Self(self.0 | Self::SDIO_INT),
+            Interrupt::DataEndBitError => Self(self.0 | Self::DEE),
+            Interrupt::AutoCommandDone => Self(self.0 | Self::ACD),
+            Interrupt::DataStartError => Self(self.0 | Self::DSE_BC),
+            Interrupt::CommandBusyAndIllegalWrite => Self(self.0 | Self::CB_IW),
+            Interrupt::FifoUnderrunOrOverflow => Self(self.0 | Self::FU_FO),
+            Interrupt::DataStarvationTimeout1V8SwitchDone => Self(self.0 | Self::DSTO_VSD),
+            Interrupt::DataTimeoutBootDataStart => Self(self.0 | Self::DTO_BDS),
+            Interrupt::ResponseTimeoutBootAckReceived => Self(self.0 | Self::RTO_BACK),
+            Interrupt::DataCrcError => Self(self.0 | Self::DCE),
+            Interrupt::ResponseCrcError => Self(self.0 | Self::RCE),
+            Interrupt::DataReceiveRequest => Self(self.0 | Self::DRR),
+            Interrupt::DataTransmitRequest => Self(self.0 | Self::DTR),
+            Interrupt::DataTransferComplete => Self(self.0 | Self::DTC),
+            Interrupt::CommandComplete => Self(self.0 | Self::CC),
+            Interrupt::ResponseError => Self(self.0 | Self::RE),
+        }
+    }
+}
+
+/// State register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
 // note: read-only register, no write functions
-// TODO fifo_level (u16)
-// TODO card_data_busy
-// TODO fifo_full
-// TODO fifo_empty
+pub struct Status(u32);
 
-// TODO pub struct FifoThreshold
+impl Status {
+    const FIFO_LEVEL: u32 = 0x1FF << 17;
+    const CARD_BUSY: u32 = 1 << 9;
+    const FIFO_FULL: u32 = 1 << 3;
+    const FIFO_EMPTY: u32 = 1 << 2;
 
-// TODO burst_size, set_burst_size, enum BurstSize { One, Four, Eight, Sixteen }
-// TODO receive_trigger_level, set_receive_trigger_level (u8)
-// TODO transmit_trigger_level, set_transmit_trigger_level (u8)
+    /// Get FIFO level.
+    #[inline]
+    pub fn fifo_level(self) -> u16 {
+        ((self.0 & Self::FIFO_LEVEL) >> 17) as u16
+    }
+    /// Is the card busy?
+    #[inline]
+    pub fn card_busy(self) -> bool {
+        self.0 & Self::CARD_BUSY != 0
+    }
+    /// Is the FIFO full?
+    #[inline]
+    pub fn fifo_full(self) -> bool {
+        self.0 & Self::FIFO_FULL != 0
+    }
+    /// Is the FIFO empty?
+    #[inline]
+    pub fn fifo_empty(self) -> bool {
+        self.0 & Self::FIFO_EMPTY != 0
+    }
+}
 
-// TODO pub struct NewTimingSet
+/// FIFO water level register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct FifoWaterLevel(u32);
 
-// 31 MODE_SELECT
-// TODO is_new_mode_enabled, enable_new_mode, disable_new_mode
-// 9:8 DAT_SAMPLE_TIMING_PHASE
-// TODO sample_timing_phase, set_sample_timing_phase, enum TimingPhase { Offset90, Offset180, Offset170, Offset0 }
+/// BurstSize.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BurstSize {
+    /// 1 byte.
+    OneBit,
+    /// 4 bytes.
+    FourBit,
+    /// 8 bytes.
+    EightBit,
+    /// 16 bytes.
+    SixteenBit,
+}
 
-// TODO pub struct DriveDelay
+impl FifoWaterLevel {
+    const BSIZE_OF_TRANS: u32 = 0x7 << 28;
+    const RX_TL: u32 = 0xFF << 16;
+    const TX_TL: u32 = 0xFF << 0;
 
-// TODO data_drive_phase, set_data_drive_phase (DrivePhase)
-// TODO command_drive_phase, set_command_drive_phase (DrivePhase)
-// TODO enum DrivePhase { Sdr90Ddr45, Sdr180Ddr90 }
+    /// Get the burst size of the transmitter. Value is from 0 to 3.(4 to 7 are reserved)
+    #[inline]
+    pub fn burst_size(self) -> BurstSize {
+        match (self.0 & Self::BSIZE_OF_TRANS) >> 28 {
+            0 => BurstSize::OneBit,
+            1 => BurstSize::FourBit,
+            2 => BurstSize::EightBit,
+            3 => BurstSize::SixteenBit,
+            _ => unreachable!(),
+        }
+    }
+    /// Set the burst size of the transmitter. Value is from 0 to 3.(4 to 7 are reserved)
+    #[inline]
+    pub fn set_burst_size(self, bsize: BurstSize) -> Self {
+        Self(self.0 & !Self::BSIZE_OF_TRANS | (bsize as u32) << 28)
+    }
+    /// Get the receive trigger level(0xFF is reserved).
+    #[inline]
+    pub fn receive_trigger_level(self) -> u8 {
+        ((self.0 & Self::RX_TL) >> 16) as u8
+    }
+    /// Set the receive trigger level(0x0 to 0xFE, 0xFF is reserved).
+    #[inline]
+    pub fn set_receive_trigger_level(self, level: u8) -> Self {
+        Self(self.0 & !Self::RX_TL | (level as u32) << 16)
+    }
+    /// Get the transmit trigger level(0x1 to 0xFF, 0x0 is no trigger).
+    #[inline]
+    pub fn transmit_trigger_level(self) -> u8 {
+        ((self.0 & Self::TX_TL) >> 0) as u8
+    }
+    /// Set the transmit trigger level(0x0 to 0xFF, 0x0 is no trigger).
+    #[inline]
+    pub fn set_transmit_trigger_level(self, level: u8) -> Self {
+        Self(self.0 & !Self::TX_TL | (level as u32) << 0)
+    }
+}
+
+/// New timing set register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct NewTimingSet(u32);
+
+/// Timing phase.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NTS_TimingPhase {
+    Offset90,
+    Offset180,
+    Offset270,
+    Offset0,
+}
+
+impl NewTimingSet {
+    const MODE_SELECT: u32 = 1 << 31;
+    const DAT_SAMPLE_TIMING_PHASE: u32 = 0x3 << 8;
+
+    /// If new mode is enabled.
+    #[inline]
+    pub fn is_new_mode_enabled(self) -> bool {
+        (self.0 & Self::MODE_SELECT) != 0
+    }
+    /// Enable new mode.
+    #[inline]
+    pub fn enable_new_mode(self) -> Self {
+        Self(self.0 | Self::MODE_SELECT)
+    }
+    /// Disable new mode.
+    #[inline]
+    pub fn disable_new_mode(self) -> Self {
+        Self(self.0 & !Self::MODE_SELECT)
+    }
+    /// Get timing phase.
+    #[inline]
+    pub fn sample_timing_phase(self) -> NTS_TimingPhase {
+        match (self.0 & Self::DAT_SAMPLE_TIMING_PHASE) >> 8 {
+            0x0 => NTS_TimingPhase::Offset90,
+            0x1 => NTS_TimingPhase::Offset180,
+            0x2 => NTS_TimingPhase::Offset270,
+            0x3 => NTS_TimingPhase::Offset0,
+            _ => unreachable!(),
+        }
+    }
+    /// Set timing phase.
+    #[inline]
+    pub fn set_sample_timing_phase(self, phase: NTS_TimingPhase) -> Self {
+        Self((self.0 & !Self::DAT_SAMPLE_TIMING_PHASE) | ((phase as u32) << 8))
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct DriveDelayControl(u32);
+
+/// Timing phase.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DDC_TimingPhase {
+    ///Offset is 90 degrees at SDR mode, 45 degrees at DDR mode.
+    Sdr90Ddr45,
+    ///Offset is 180 degrees at SDR mode, 90 degrees at DDR mode.
+    Sdr180Ddr90,
+}
+
+impl DriveDelayControl {
+    const DAT_DRV_PH_SEL: u32 = 1 << 17;
+    const CMD_DRV_PH_SEL: u32 = 1 << 16;
+
+    /// Get data drive phase.
+    #[inline]
+    pub fn data_drive_phase(self) -> DDC_TimingPhase {
+        match (self.0 & Self::DAT_DRV_PH_SEL) >> 17 {
+            0x0 => DDC_TimingPhase::Sdr90Ddr45,
+            0x1 => DDC_TimingPhase::Sdr180Ddr90,
+            _ => unreachable!(),
+        }
+    }
+    /// Set data drive phase.
+    #[inline]
+    pub fn set_data_drive_phase(self, phase: DDC_TimingPhase) -> Self {
+        Self((self.0 & !Self::DAT_DRV_PH_SEL) | ((phase as u32) << 17))
+    }
+    /// Get command drive phase.
+    #[inline]
+    pub fn command_drive_phase(self) -> DDC_TimingPhase {
+        match (self.0 & Self::CMD_DRV_PH_SEL) >> 16 {
+            0x0 => DDC_TimingPhase::Sdr90Ddr45,
+            0x1 => DDC_TimingPhase::Sdr180Ddr90,
+            _ => unreachable!(),
+        }
+    }
+    /// Set command drive phase.
+    #[inline]
+    pub fn set_command_drive_phase(self, phase: DDC_TimingPhase) -> Self {
+        Self((self.0 & !Self::CMD_DRV_PH_SEL) | ((phase as u32) << 16))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AccessMode, Argument, BlockSize, BurstSize, BusWidth, Bus_Width, ByteCount, ClockControl,
+        Command, DDC_TimingPhase, DdrMode, DriveDelayControl, FifoWaterLevel, GlobalControl,
+        Interrupt, InterruptMask, InterruptStateMasked, InterruptStateRaw, NTS_TimingPhase,
+        NewTimingSet, RegisterBlock, Status, TimeOut, TransferDirection,
+    };
+    use memoffset::offset_of;
+    #[test]
+    fn offset_smhc() {
+        assert_eq!(offset_of!(RegisterBlock, global_control), 0x0);
+        assert_eq!(offset_of!(RegisterBlock, clock_control), 0x4);
+        assert_eq!(offset_of!(RegisterBlock, timeout), 0x08);
+        assert_eq!(offset_of!(RegisterBlock, bus_width), 0x0C);
+        assert_eq!(offset_of!(RegisterBlock, block_size), 0x10);
+        assert_eq!(offset_of!(RegisterBlock, byte_count), 0x14);
+        assert_eq!(offset_of!(RegisterBlock, command), 0x18);
+        assert_eq!(offset_of!(RegisterBlock, argument), 0x1C);
+        assert_eq!(offset_of!(RegisterBlock, responses), 0x20);
+        assert_eq!(offset_of!(RegisterBlock, interrupt_mask), 0x30);
+        assert_eq!(offset_of!(RegisterBlock, interrupt_state_masked), 0x34);
+        assert_eq!(offset_of!(RegisterBlock, interrupt_state_raw), 0x38);
+        assert_eq!(offset_of!(RegisterBlock, status), 0x3C);
+        assert_eq!(offset_of!(RegisterBlock, fifo_water_level), 0x40);
+        assert_eq!(offset_of!(RegisterBlock, new_timing_set), 0x5C);
+        assert_eq!(offset_of!(RegisterBlock, dma_control), 0x80);
+        assert_eq!(offset_of!(RegisterBlock, dma_descriptor_base), 0x84);
+        assert_eq!(offset_of!(RegisterBlock, dma_state), 0x88);
+        assert_eq!(offset_of!(RegisterBlock, dma_interrupt_enable), 0x8C);
+        assert_eq!(offset_of!(RegisterBlock, drive_delay_control), 0x140);
+        assert_eq!(offset_of!(RegisterBlock, skew_control), 0x184);
+        assert_eq!(offset_of!(RegisterBlock, fifo), 0x200);
+    }
+
+    #[test]
+    fn struct_global_control_functions() {
+        let mut val = GlobalControl(0x0);
+
+        val = val.set_access_mode(AccessMode::Ahb);
+        assert_eq!(val.access_mode(), AccessMode::Ahb);
+        assert_eq!(val.0, 0x80000000);
+
+        val = val.set_access_mode(AccessMode::Dma);
+        assert_eq!(val.access_mode(), AccessMode::Dma);
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.set_ddr_mode(DdrMode::Ddr);
+        assert_eq!(val.ddr_mode(), DdrMode::Ddr);
+        assert_eq!(val.0, 0x00000400);
+
+        val = val.set_ddr_mode(DdrMode::Sdr);
+        assert_eq!(val.ddr_mode(), DdrMode::Sdr);
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_dma();
+        assert!(val.is_dma_enabled());
+        assert_eq!(val.0, 0x00000020);
+
+        val = val.disable_dma();
+        assert!(!val.is_dma_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_interrupt();
+        assert!(val.is_interrupt_enabled());
+        assert_eq!(val.0, 0x000000010);
+
+        val = val.disable_interrupt();
+        assert!(!val.is_interrupt_enabled());
+        assert_eq!(val.0, 0x000000000);
+
+        val = val.set_dma_reset();
+        assert_eq!(val.0, 0x00000004);
+
+        val = GlobalControl(0x0);
+        val = val.set_fifo_reset();
+        assert_eq!(val.0, 0x00000002);
+
+        val = GlobalControl(0x0);
+        val = val.set_software_reset();
+        assert_eq!(val.0, 0x00000001);
+
+        // TODO has_dma_reset
+        // TODO has_fifo_reset
+        // TODO has_software_reset
+    }
+
+    #[test]
+    fn struct_clock_control_functions() {
+        let mut val = ClockControl(0x0);
+
+        val = val.enable_mask_data0();
+        assert!(val.is_mask_data0_enabled());
+        assert_eq!(val.0, 0x80000000);
+
+        val = val.disable_mask_data0();
+        assert!(!val.is_mask_data0_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_card_clock();
+        assert!(val.is_card_clock_enabled());
+        assert_eq!(val.0, 0x00020000);
+
+        val = val.disable_card_clock();
+        assert!(!val.is_card_clock_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.set_card_clock_divider(0xFF);
+        assert_eq!(val.card_clock_divider(), 0xFF);
+        assert_eq!(val.0, 0x000000FF);
+    }
+
+    #[test]
+    fn struct_timeout_functions() {
+        let mut val = TimeOut(0x0);
+
+        val = val.set_data_timeout_limit(0xFFFFFF);
+        assert_eq!(val.data_timeout_limit(), 0xFFFFFF);
+        assert_eq!(val.0, 0xFFFFFF00);
+    }
+
+    #[test]
+    fn struct_bus_width_functions() {
+        let mut val = BusWidth(0x0);
+
+        val = val.set_bus_width(Bus_Width::OneBit);
+        assert_eq!(val.bus_width(), Bus_Width::OneBit);
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.set_bus_width(Bus_Width::FourBit);
+        assert_eq!(val.bus_width(), Bus_Width::FourBit);
+        assert_eq!(val.0, 0x00000001);
+
+        val = val.set_bus_width(Bus_Width::EightBit);
+        assert_eq!(val.bus_width(), Bus_Width::EightBit);
+        assert_eq!(val.0, 0x00000002);
+    }
+
+    #[test]
+    fn struct_block_size_functions() {
+        let mut val = BlockSize(0x0);
+
+        val = val.set_block_size(0xFFFF);
+        assert_eq!(val.block_size(), 0xFFFF);
+        assert_eq!(val.0, 0x0000FFFF);
+    }
+
+    #[test]
+    fn struct_byte_count_functions() {
+        let mut val = ByteCount(0x0);
+
+        val = val.set_byte_count(0xFFFFFFFF);
+        assert_eq!(val.byte_count(), 0xFFFFFFFF);
+        assert_eq!(val.0, 0xFFFFFFFF);
+    }
+
+    #[test]
+    fn struct_command_functions() {
+        let mut val = Command(0x0);
+
+        val = val.set_command_start();
+        assert_eq!(val.0, 0x80000000);
+
+        val = Command(0x0);
+        val = val.enable_change_clock();
+        assert!(val.is_change_clock_enabled());
+        assert_eq!(val.0, 0x00200000);
+
+        val = val.disable_change_clock();
+        assert!(!val.is_change_clock_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_send_init_seq();
+        assert!(val.is_send_init_seq_enabled());
+        assert_eq!(val.0, 0x00008000);
+
+        val = val.disable_send_init_seq();
+        assert!(!val.is_send_init_seq_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_stop_abort();
+        assert!(val.is_stop_abort_enabled());
+        assert_eq!(val.0, 0x00004000);
+
+        val = val.disable_stop_abort();
+        assert!(!val.is_stop_abort_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_wait_for_complete();
+        assert!(val.is_wait_for_complete_enabled());
+        assert_eq!(val.0, 0x00002000);
+
+        val = val.disable_wait_for_complete();
+        assert!(!val.is_wait_for_complete_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_auto_stop();
+        assert!(val.is_auto_stop_enabled());
+        assert_eq!(val.0, 0x00001000);
+
+        val = val.disable_auto_stop();
+        assert!(!val.is_auto_stop_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.set_transfer_direction(TransferDirection::Write);
+        assert_eq!(val.transfer_direction(), TransferDirection::Write);
+        assert_eq!(val.0, 0x00000400);
+
+        val = val.set_transfer_direction(TransferDirection::Read);
+        assert_eq!(val.transfer_direction(), TransferDirection::Read);
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_data_transfer();
+        assert!(val.is_data_transfer_enabled());
+        assert_eq!(val.0, 0x00000200);
+
+        val = val.disable_data_transfer();
+        assert!(!val.is_data_transfer_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_check_response_crc();
+        assert!(val.is_check_response_crc_enabled());
+        assert_eq!(val.0, 0x00000100);
+
+        val = val.disable_check_response_crc();
+        assert!(!val.is_check_response_crc_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_long_response();
+        assert!(val.is_long_response_enabled());
+        assert_eq!(val.0, 0x00000080);
+
+        val = val.disable_long_response();
+        assert!(!val.is_long_response_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.enable_response_receive();
+        assert!(val.is_response_receive_enabled());
+        assert_eq!(val.0, 0x00000040);
+
+        val = val.disable_response_receive();
+        assert!(!val.is_response_receive_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.set_command_index(0x3F);
+        assert_eq!(val.command_index(), 0x3F);
+        assert_eq!(val.0, 0x0000003F);
+
+        // TODO has_command_start
+    }
+
+    #[test]
+    fn struct_argument_functions() {
+        let mut val = Argument(0x0);
+
+        val = val.set_argument(0xFFFFFFFF);
+        assert_eq!(val.argument(), 0xFFFFFFFF);
+        assert_eq!(val.0, 0xFFFFFFFF);
+    }
+
+    #[test]
+    fn struct_interrupt_mask_functions() {
+        let mut val = InterruptMask(0x0);
+
+        for i in 0..18 as u8 {
+            let int_tmp = match i {
+                0 => Interrupt::CardRemoved,
+                1 => Interrupt::CardInserted,
+                2 => Interrupt::Sdio,
+                3 => Interrupt::DataEndBitError,
+                4 => Interrupt::AutoCommandDone,
+                5 => Interrupt::DataStartError,
+                6 => Interrupt::CommandBusyAndIllegalWrite,
+                7 => Interrupt::FifoUnderrunOrOverflow,
+                8 => Interrupt::DataStarvationTimeout1V8SwitchDone,
+                9 => Interrupt::DataTimeoutBootDataStart,
+                10 => Interrupt::ResponseTimeoutBootAckReceived,
+                11 => Interrupt::DataCrcError,
+                12 => Interrupt::ResponseCrcError,
+                13 => Interrupt::DataReceiveRequest,
+                14 => Interrupt::DataTransmitRequest,
+                15 => Interrupt::DataTransferComplete,
+                16 => Interrupt::CommandComplete,
+                17 => Interrupt::ResponseError,
+                _ => unreachable!(),
+            };
+
+            let val_tmp = match i {
+                0 => 0x80000000,
+                1 => 0x40000000,
+                2 => 0x00010000,
+                3 => 0x00008000,
+                4 => 0x00004000,
+                5 => 0x00002000,
+                6 => 0x00001000,
+                7 => 0x00000800,
+                8 => 0x00000400,
+                9 => 0x00000200,
+                10 => 0x00000100,
+                11 => 0x00000080,
+                12 => 0x00000040,
+                13 => 0x00000020,
+                14 => 0x00000010,
+                15 => 0x00000008,
+                16 => 0x00000004,
+                17 => 0x00000002,
+                _ => unreachable!(),
+            };
+
+            val = val.mask_interrupt(int_tmp);
+            assert!(val.is_interrupt_masked(int_tmp));
+            assert_eq!(val.0, val_tmp);
+
+            val = val.unmask_interrupt(int_tmp);
+            assert!(!val.is_interrupt_masked(int_tmp));
+            assert_eq!(val.0, 0x00000000);
+            
+        }
+    }
+
+    #[test]
+    fn struct_interrupt_state_masked_functions() {
+        let mut val = InterruptStateMasked(0x0);
+
+        for i in 0..18 as u8 {
+            let int_tmp = match i {
+                0x0 => Interrupt::CardRemoved,
+                1 => Interrupt::CardInserted,
+                2 => Interrupt::Sdio,
+                3 => Interrupt::DataEndBitError,
+                4 => Interrupt::AutoCommandDone,
+                5 => Interrupt::DataStartError,
+                6 => Interrupt::CommandBusyAndIllegalWrite,
+                7 => Interrupt::FifoUnderrunOrOverflow,
+                8 => Interrupt::DataStarvationTimeout1V8SwitchDone,
+                9 => Interrupt::DataTimeoutBootDataStart,
+                10 => Interrupt::ResponseTimeoutBootAckReceived,
+                11 => Interrupt::DataCrcError,
+                12 => Interrupt::ResponseCrcError,
+                13 => Interrupt::DataReceiveRequest,
+                14 => Interrupt::DataTransmitRequest,
+                15 => Interrupt::DataTransferComplete,
+                16 => Interrupt::CommandComplete,
+                17 => Interrupt::ResponseError,
+                _ => unreachable!(),
+            };
+
+            let val_tmp = match i {
+                0 => 0x80000000,
+                1 => 0x40000000,
+                2 => 0x00010000,
+                3 => 0x00008000,
+                4 => 0x00004000,
+                5 => 0x00002000,
+                6 => 0x00001000,
+                7 => 0x00000800,
+                8 => 0x00000400,
+                9 => 0x00000200,
+                10 => 0x00000100,
+                11 => 0x00000080,
+                12 => 0x00000040,
+                13 => 0x00000020,
+                14 => 0x00000010,
+                15 => 0x00000008,
+                16 => 0x00000004,
+                17 => 0x00000002,
+                _ => unreachable!(),
+            };
+
+            val = InterruptStateMasked(val_tmp);
+            assert!(val.has_interrupt(int_tmp));
+        }
+    }
+
+    #[test]
+    fn struct_interrupt_state_raw_functions() {
+        let mut val =InterruptStateRaw(0x0);
+
+        for i in 0..18 as u8 {
+            let int_tmp = match i {
+                0 => Interrupt::CardRemoved,
+                1 => Interrupt::CardInserted,
+                2 => Interrupt::Sdio,
+                3 => Interrupt::DataEndBitError,
+                4 => Interrupt::AutoCommandDone,
+                5 => Interrupt::DataStartError,
+                6 => Interrupt::CommandBusyAndIllegalWrite,
+                7 => Interrupt::FifoUnderrunOrOverflow,
+                8 => Interrupt::DataStarvationTimeout1V8SwitchDone,
+                9 => Interrupt::DataTimeoutBootDataStart,
+                10 => Interrupt::ResponseTimeoutBootAckReceived,
+                11 => Interrupt::DataCrcError,
+                12 => Interrupt::ResponseCrcError,
+                13 => Interrupt::DataReceiveRequest,
+                14 => Interrupt::DataTransmitRequest,
+                15 => Interrupt::DataTransferComplete,
+                16 => Interrupt::CommandComplete,
+                17 => Interrupt::ResponseError,
+                _ => unreachable!(),
+            };
+
+            let val_tmp = match i {
+                0 => 0x80000000,
+                1 => 0x40000000,
+                2 => 0x00010000,
+                3 => 0x00008000,
+                4 => 0x00004000,
+                5 => 0x00002000,
+                6 => 0x00001000,
+                7 => 0x00000800,
+                8 => 0x00000400,
+                9 => 0x00000200,
+                10 => 0x00000100,
+                11 => 0x00000080,
+                12 => 0x00000040,
+                13 => 0x00000020,
+                14 => 0x00000010,
+                15 => 0x00000008,
+                16 => 0x00000004,
+                17 => 0x00000002,
+                _ => unreachable!(),
+            };
+
+            val = InterruptStateRaw(val_tmp);
+            assert!(val.has_interrupt(int_tmp));
+
+            val = InterruptStateRaw(0x0);
+            val = val.clear_interrupt(int_tmp);
+            assert!(val.has_interrupt(int_tmp));
+        }
+    }
+
+    #[test]
+    fn struct_status_functions() {
+        let mut val = Status(0x0);
+
+        val = Status(0x03FE0000);
+        assert_eq!(val.fifo_level(), 0x1FF);
+
+        val = Status(0x00000200);
+        assert!(val.card_busy());
+
+        val = Status(0x00000008);
+        assert!(val.fifo_full());
+
+        val = Status(0x00000004);
+        assert!(val.fifo_empty());
+    }
+
+    #[test]
+    fn struct_fifo_water_level_functions() {
+        let mut val = FifoWaterLevel(0x0);
+
+        for i in 0..4 as u8 {
+            let bs_tmp = match i {
+                0x0 => BurstSize::OneBit,
+                0x1 => BurstSize::FourBit,
+                0x2 => BurstSize::EightBit,
+                0x3 => BurstSize::SixteenBit,
+                _ => unreachable!(),
+            };
+
+            let val_tmp = match i {
+                0x0 => 0x00000000,
+                0x1 => 0x10000000,
+                0x2 => 0x20000000,
+                0x3 => 0x30000000,
+                _ => unreachable!(),
+            };
+
+            val = val.set_burst_size(bs_tmp);
+            assert_eq!(val.burst_size(), bs_tmp);
+            assert_eq!(val.0, val_tmp);
+        }
+
+        val = FifoWaterLevel(0x0);
+        val = val.set_receive_trigger_level(0xFF);
+        assert_eq!(val.receive_trigger_level(), 0xFF);
+        assert_eq!(val.0, 0x00FF0000);
+
+        val = FifoWaterLevel(0x0);
+        val = val.set_transmit_trigger_level(0xFF);
+        assert_eq!(val.transmit_trigger_level(), 0xFF);
+        assert_eq!(val.0, 0x000000FF);
+    }
+
+    #[test]
+    fn struct_new_timing_set_functions() {
+        let mut val = NewTimingSet(0x0);
+
+        val = val.enable_new_mode();
+        assert!(val.is_new_mode_enabled());
+        assert_eq!(val.0, 0x80000000);
+
+        val = val.disable_new_mode();
+        assert!(!val.is_new_mode_enabled());
+        assert_eq!(val.0, 0x00000000);
+
+        for i in 0..4 as u8 {
+            let tp_tmp = match i {
+                0x0 => NTS_TimingPhase::Offset90,
+                0x1 => NTS_TimingPhase::Offset180,
+                0x2 => NTS_TimingPhase::Offset270,
+                0x3 => NTS_TimingPhase::Offset0,
+                _ => unreachable!(),
+            };
+
+            let val_tmp = match i {
+                0x0 => 0x00000000,
+                0x1 => 0x00000100,
+                0x2 => 0x00000200,
+                0x3 => 0x00000300,
+                _ => unreachable!(),
+            };
+
+            val = val.set_sample_timing_phase(tp_tmp);
+            assert_eq!(val.sample_timing_phase(), tp_tmp);
+            assert_eq!(val.0, val_tmp);
+        }
+    }
+
+    #[test]
+    fn struct_drive_delay_control_functions() {
+        let mut val = DriveDelayControl(0x0);
+
+        val = val.set_data_drive_phase(DDC_TimingPhase::Sdr180Ddr90);
+        assert_eq!(val.data_drive_phase(), DDC_TimingPhase::Sdr180Ddr90);
+        assert_eq!(val.0, 0x00020000);
+
+        val = val.set_data_drive_phase(DDC_TimingPhase::Sdr90Ddr45);
+        assert_eq!(val.data_drive_phase(), DDC_TimingPhase::Sdr90Ddr45);
+        assert_eq!(val.0, 0x00000000);
+
+        val = val.set_command_drive_phase(DDC_TimingPhase::Sdr180Ddr90);
+        assert_eq!(val.command_drive_phase(), DDC_TimingPhase::Sdr180Ddr90);
+        assert_eq!(val.0, 0x00010000);
+
+        val = val.set_command_drive_phase(DDC_TimingPhase::Sdr90Ddr45);
+        assert_eq!(val.command_drive_phase(), DDC_TimingPhase::Sdr90Ddr45);
+        assert_eq!(val.0, 0x00000000);
+    }
+}

--- a/src/smhc.rs
+++ b/src/smhc.rs
@@ -58,21 +58,21 @@ pub struct RegisterBlock {
 #[repr(transparent)]
 pub struct GlobalControl(u32);
 
-/// FIFO access mode
+/// FIFO access mode.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AccessMode {
-    // Dma bus
+    // Dma bus.
     Dma,
-    // Ahb bus
+    // Ahb bus.
     Ahb,
 }
 
-/// DDR mode
+/// DDR mode.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DdrMode {
-    // SDR mode
+    // SDR mode.
     Sdr,
-    // DDR mode
+    // DDR mode.
     Ddr,
 }
 
@@ -166,10 +166,10 @@ impl GlobalControl {
     pub const fn set_software_reset(self) -> Self {
         Self(self.0 | Self::SOFT_RST)
     }
-    // note: DMA_RST, FIFO_RST and SOFT_RST are write-1-set, auto-cleared by hardware
-    // TODO has_dma_reset
-    // TODO has_fifo_reset
-    // TODO has_software_reset
+    // Note: DMA_RST, FIFO_RST and SOFT_RST are write-1-set, auto-cleared by hardware.
+    // TODO has_dma_reset.
+    // TODO has_fifo_reset.
+    // TODO has_software_reset.
 }
 
 /// Clock control register.
@@ -247,14 +247,14 @@ impl TimeOut {
 #[repr(transparent)]
 pub struct BusWidth(u32);
 
-/// busWidth
+/// Bus width bits.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Bus_Width {
-    /// 1 bit
+pub enum BusWidthBits {
+    /// 1 bit.
     OneBit,
-    /// 4 bit
+    /// 4 bit.
     FourBit,
-    /// 8 bit
+    /// 8 bit.
     EightBit,
 }
 
@@ -262,17 +262,17 @@ impl BusWidth {
     const CARD_WID: u32 = 0x3 << 0;
     /// Get bus width.
     #[inline]
-    pub const fn bus_width(self) -> Bus_Width {
+    pub const fn bus_width(self) -> BusWidthBits {
         match (self.0 & Self::CARD_WID) >> 0 {
-            0x0 => Bus_Width::OneBit,
-            0x1 => Bus_Width::FourBit,
-            0x2 | 0x3 => Bus_Width::EightBit,
+            0x0 => BusWidthBits::OneBit,
+            0x1 => BusWidthBits::FourBit,
+            0x2 | 0x3 => BusWidthBits::EightBit,
             _ => unreachable!(),
         }
     }
     /// Set bus width.
     #[inline]
-    pub const fn set_bus_width(self, width: Bus_Width) -> Self {
+    pub const fn set_bus_width(self, width: BusWidthBits) -> Self {
         Self((self.0 & !Self::CARD_WID) | ((width as u32) << 0))
     }
 }
@@ -320,12 +320,12 @@ impl ByteCount {
 #[repr(transparent)]
 pub struct Command(u32);
 
-/// busWidth
+/// Transfer direction.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TransferDirection {
-    /// Read from card
+    /// Read from card.
     Read,
-    /// Write to card
+    /// Write to card.
     Write,
 }
 
@@ -378,7 +378,7 @@ impl Command {
     pub const fn disable_send_init_seq(self) -> Self {
         Self(self.0 & !Self::SEND_INIT_SEQ)
     }
-    /// if stop abort command is enabled.
+    /// If stop abort command is enabled.
     #[inline]
     pub const fn is_stop_abort_enabled(self) -> bool {
         (self.0 & Self::STOP_ABT_CMD) != 0
@@ -507,8 +507,8 @@ impl Command {
     pub const fn set_command_index(self, val: u8) -> Self {
         Self((self.0 & !Self::CMD_IDX) | ((val as u32) << 0))
     }
-    // bit 31 (SMHC_CMD_START, or CMD_LOAD) is write-1-set by software, auto-cleared by hardware
-    // TODO has_command_start
+    // Bit 31 (SMHC_CMD_START, or CMD_LOAD) is write-1-set by software, auto-cleared by hardware.
+    // TODO has_command_start.
 }
 
 /// Argument register.
@@ -519,14 +519,14 @@ pub struct Argument(u32);
 impl Argument {
     const CMD_ARG: u32 = 0xFFFFFFFF << 0;
 
-    /// Get argument
+    /// Get argument.
     #[inline]
-    pub fn argument(self) -> u32 {
+    pub const fn argument(self) -> u32 {
         (self.0 & Self::CMD_ARG) as u32 >> 0
     }
-    /// Set argument
+    /// Set argument.
     #[inline]
-    pub fn set_argument(self, arg: u32) -> Self {
+    pub const fn set_argument(self, arg: u32) -> Self {
         Self((self.0 & !Self::CMD_ARG) | ((arg as u32) << 0))
     }
 }
@@ -536,7 +536,7 @@ impl Argument {
 #[repr(transparent)]
 pub struct InterruptMask(u32);
 
-/// interrupt
+/// Interrupt register.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Interrupt {
     CardRemoved,
@@ -579,8 +579,8 @@ impl InterruptMask {
     const CC_INT_EN: u32 = 1 << 2;
     const RE_INT_EN: u32 = 1 << 1;
 
-    /// If the interrupt is masked.
-    pub fn is_interrupt_masked(self, interrupt: Interrupt) -> bool {
+    /// If the interrupt is unmasked.
+    pub const fn is_interrupt_unmasked(self, interrupt: Interrupt) -> bool {
         match interrupt {
             Interrupt::CardRemoved => self.0 & Self::CARD_REMOVAL_INT_EN != 0,
             Interrupt::CardInserted => self.0 & Self::CARD_INSERT_INT_EN != 0,
@@ -602,9 +602,9 @@ impl InterruptMask {
             Interrupt::ResponseError => self.0 & Self::RE_INT_EN != 0,
         }
     }
-    /// Mask the specified interrupt.
+    /// Unmask the specified interrupt.
     #[inline]
-    pub fn mask_interrupt(self, interrupt: Interrupt) -> Self {
+    pub const fn unmask_interrupt(self, interrupt: Interrupt) -> Self {
         match interrupt {
             Interrupt::CardRemoved => Self(self.0 | Self::CARD_REMOVAL_INT_EN),
             Interrupt::CardInserted => Self(self.0 | Self::CARD_INSERT_INT_EN),
@@ -626,9 +626,9 @@ impl InterruptMask {
             Interrupt::ResponseError => Self(self.0 | Self::RE_INT_EN),
         }
     }
-    /// Unmask the specified interrupt.
+    /// Mask the specified interrupt.
     #[inline]
-    pub fn unmask_interrupt(self, interrupt: Interrupt) -> Self {
+    pub const fn mask_interrupt(self, interrupt: Interrupt) -> Self {
         match interrupt {
             Interrupt::CardRemoved => Self(self.0 & !Self::CARD_REMOVAL_INT_EN),
             Interrupt::CardInserted => Self(self.0 & !Self::CARD_INSERT_INT_EN),
@@ -664,7 +664,7 @@ impl InterruptStateMasked {
     const M_DEE_INT: u32 = 1 << 15;
     const M_ACD_INT: u32 = 1 << 14;
     const M_DSE_BC_INT: u32 = 1 << 13;
-    const M_CB_IW_INT_: u32 = 1 << 12;
+    const M_CB_IW_INT: u32 = 1 << 12;
     const M_FU_FO_INT: u32 = 1 << 11;
     const M_DSTO_VSD_INT: u32 = 1 << 10;
     const M_DTO_BDS_INT: u32 = 1 << 9;
@@ -679,7 +679,7 @@ impl InterruptStateMasked {
 
     /// If the interrupt occurs.
     #[inline]
-    pub fn has_interrupt(self, interrupt: Interrupt) -> bool {
+    pub const fn has_interrupt(self, interrupt: Interrupt) -> bool {
         match interrupt {
             Interrupt::CardRemoved => self.0 & Self::M_CARD_REMOVAL_INT != 0,
             Interrupt::CardInserted => self.0 & Self::M_CARD_INSERT_INT != 0,
@@ -687,7 +687,7 @@ impl InterruptStateMasked {
             Interrupt::DataEndBitError => self.0 & Self::M_DEE_INT != 0,
             Interrupt::AutoCommandDone => self.0 & Self::M_ACD_INT != 0,
             Interrupt::DataStartError => self.0 & Self::M_DSE_BC_INT != 0,
-            Interrupt::CommandBusyAndIllegalWrite => self.0 & Self::M_CB_IW_INT_ != 0,
+            Interrupt::CommandBusyAndIllegalWrite => self.0 & Self::M_CB_IW_INT != 0,
             Interrupt::FifoUnderrunOrOverflow => self.0 & Self::M_FU_FO_INT != 0,
             Interrupt::DataStarvationTimeout1V8SwitchDone => self.0 & Self::M_DSTO_VSD_INT != 0,
             Interrupt::DataTimeoutBootDataStart => self.0 & Self::M_DTO_BDS_INT != 0,
@@ -730,7 +730,7 @@ impl InterruptStateRaw {
 
     /// If the interrupt occurs.
     #[inline]
-    pub fn has_interrupt(self, interrupt: Interrupt) -> bool {
+    pub const fn has_interrupt(self, interrupt: Interrupt) -> bool {
         match interrupt {
             Interrupt::CardRemoved => self.0 & Self::CARD_REMOVAL != 0,
             Interrupt::CardInserted => self.0 & Self::CARD_INSERT != 0,
@@ -754,7 +754,7 @@ impl InterruptStateRaw {
     }
     /// Clears the specified interrupt.
     #[inline]
-    pub fn clear_interrupt(self, interrupt: Interrupt) -> Self {
+    pub const fn clear_interrupt(self, interrupt: Interrupt) -> Self {
         match interrupt {
             Interrupt::CardRemoved => Self(self.0 | Self::CARD_REMOVAL),
             Interrupt::CardInserted => Self(self.0 | Self::CARD_INSERT),
@@ -792,22 +792,22 @@ impl Status {
 
     /// Get FIFO level.
     #[inline]
-    pub fn fifo_level(self) -> u16 {
+    pub const fn fifo_level(self) -> u16 {
         ((self.0 & Self::FIFO_LEVEL) >> 17) as u16
     }
     /// Is the card busy?
     #[inline]
-    pub fn card_busy(self) -> bool {
+    pub const fn card_busy(self) -> bool {
         self.0 & Self::CARD_BUSY != 0
     }
     /// Is the FIFO full?
     #[inline]
-    pub fn fifo_full(self) -> bool {
+    pub const fn fifo_full(self) -> bool {
         self.0 & Self::FIFO_FULL != 0
     }
     /// Is the FIFO empty?
     #[inline]
-    pub fn fifo_empty(self) -> bool {
+    pub const fn fifo_empty(self) -> bool {
         self.0 & Self::FIFO_EMPTY != 0
     }
 }
@@ -817,7 +817,7 @@ impl Status {
 #[repr(transparent)]
 pub struct FifoWaterLevel(u32);
 
-/// BurstSize.
+/// Burst size.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BurstSize {
     /// 1 byte.
@@ -837,7 +837,7 @@ impl FifoWaterLevel {
 
     /// Get the burst size of the transmitter. Value is from 0 to 3.(4 to 7 are reserved)
     #[inline]
-    pub fn burst_size(self) -> BurstSize {
+    pub const fn burst_size(self) -> BurstSize {
         match (self.0 & Self::BSIZE_OF_TRANS) >> 28 {
             0 => BurstSize::OneBit,
             1 => BurstSize::FourBit,
@@ -848,27 +848,27 @@ impl FifoWaterLevel {
     }
     /// Set the burst size of the transmitter. Value is from 0 to 3.(4 to 7 are reserved)
     #[inline]
-    pub fn set_burst_size(self, bsize: BurstSize) -> Self {
+    pub const fn set_burst_size(self, bsize: BurstSize) -> Self {
         Self(self.0 & !Self::BSIZE_OF_TRANS | (bsize as u32) << 28)
     }
     /// Get the receive trigger level(0xFF is reserved).
     #[inline]
-    pub fn receive_trigger_level(self) -> u8 {
+    pub const fn receive_trigger_level(self) -> u8 {
         ((self.0 & Self::RX_TL) >> 16) as u8
     }
     /// Set the receive trigger level(0x0 to 0xFE, 0xFF is reserved).
     #[inline]
-    pub fn set_receive_trigger_level(self, level: u8) -> Self {
+    pub const fn set_receive_trigger_level(self, level: u8) -> Self {
         Self(self.0 & !Self::RX_TL | (level as u32) << 16)
     }
     /// Get the transmit trigger level(0x1 to 0xFF, 0x0 is no trigger).
     #[inline]
-    pub fn transmit_trigger_level(self) -> u8 {
+    pub const fn transmit_trigger_level(self) -> u8 {
         ((self.0 & Self::TX_TL) >> 0) as u8
     }
     /// Set the transmit trigger level(0x0 to 0xFF, 0x0 is no trigger).
     #[inline]
-    pub fn set_transmit_trigger_level(self, level: u8) -> Self {
+    pub const fn set_transmit_trigger_level(self, level: u8) -> Self {
         Self(self.0 & !Self::TX_TL | (level as u32) << 0)
     }
 }
@@ -878,9 +878,9 @@ impl FifoWaterLevel {
 #[repr(transparent)]
 pub struct NewTimingSet(u32);
 
-/// Timing phase.
+/// New timing set timing phase.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum NTS_TimingPhase {
+pub enum NtsTimingPhase {
     Offset90,
     Offset180,
     Offset270,
@@ -893,33 +893,33 @@ impl NewTimingSet {
 
     /// If new mode is enabled.
     #[inline]
-    pub fn is_new_mode_enabled(self) -> bool {
+    pub const fn is_new_mode_enabled(self) -> bool {
         (self.0 & Self::MODE_SELECT) != 0
     }
     /// Enable new mode.
     #[inline]
-    pub fn enable_new_mode(self) -> Self {
+    pub const fn enable_new_mode(self) -> Self {
         Self(self.0 | Self::MODE_SELECT)
     }
     /// Disable new mode.
     #[inline]
-    pub fn disable_new_mode(self) -> Self {
+    pub const fn disable_new_mode(self) -> Self {
         Self(self.0 & !Self::MODE_SELECT)
     }
     /// Get timing phase.
     #[inline]
-    pub fn sample_timing_phase(self) -> NTS_TimingPhase {
+    pub const fn sample_timing_phase(self) -> NtsTimingPhase {
         match (self.0 & Self::DAT_SAMPLE_TIMING_PHASE) >> 8 {
-            0x0 => NTS_TimingPhase::Offset90,
-            0x1 => NTS_TimingPhase::Offset180,
-            0x2 => NTS_TimingPhase::Offset270,
-            0x3 => NTS_TimingPhase::Offset0,
+            0x0 => NtsTimingPhase::Offset90,
+            0x1 => NtsTimingPhase::Offset180,
+            0x2 => NtsTimingPhase::Offset270,
+            0x3 => NtsTimingPhase::Offset0,
             _ => unreachable!(),
         }
     }
     /// Set timing phase.
     #[inline]
-    pub fn set_sample_timing_phase(self, phase: NTS_TimingPhase) -> Self {
+    pub const fn set_sample_timing_phase(self, phase: NtsTimingPhase) -> Self {
         Self((self.0 & !Self::DAT_SAMPLE_TIMING_PHASE) | ((phase as u32) << 8))
     }
 }
@@ -928,12 +928,12 @@ impl NewTimingSet {
 #[repr(transparent)]
 pub struct DriveDelayControl(u32);
 
-/// Timing phase.
+/// Drive delay control timing phase.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum DDC_TimingPhase {
-    ///Offset is 90 degrees at SDR mode, 45 degrees at DDR mode.
+pub enum DdcTimingPhase {
+    /// Offset is 90 degrees at SDR mode, 45 degrees at DDR mode.
     Sdr90Ddr45,
-    ///Offset is 180 degrees at SDR mode, 90 degrees at DDR mode.
+    /// Offset is 180 degrees at SDR mode, 90 degrees at DDR mode.
     Sdr180Ddr90,
 }
 
@@ -943,30 +943,30 @@ impl DriveDelayControl {
 
     /// Get data drive phase.
     #[inline]
-    pub fn data_drive_phase(self) -> DDC_TimingPhase {
+    pub const fn data_drive_phase(self) -> DdcTimingPhase {
         match (self.0 & Self::DAT_DRV_PH_SEL) >> 17 {
-            0x0 => DDC_TimingPhase::Sdr90Ddr45,
-            0x1 => DDC_TimingPhase::Sdr180Ddr90,
+            0x0 => DdcTimingPhase::Sdr90Ddr45,
+            0x1 => DdcTimingPhase::Sdr180Ddr90,
             _ => unreachable!(),
         }
     }
     /// Set data drive phase.
     #[inline]
-    pub fn set_data_drive_phase(self, phase: DDC_TimingPhase) -> Self {
+    pub const fn set_data_drive_phase(self, phase: DdcTimingPhase) -> Self {
         Self((self.0 & !Self::DAT_DRV_PH_SEL) | ((phase as u32) << 17))
     }
     /// Get command drive phase.
     #[inline]
-    pub fn command_drive_phase(self) -> DDC_TimingPhase {
+    pub const fn command_drive_phase(self) -> DdcTimingPhase {
         match (self.0 & Self::CMD_DRV_PH_SEL) >> 16 {
-            0x0 => DDC_TimingPhase::Sdr90Ddr45,
-            0x1 => DDC_TimingPhase::Sdr180Ddr90,
+            0x0 => DdcTimingPhase::Sdr90Ddr45,
+            0x1 => DdcTimingPhase::Sdr180Ddr90,
             _ => unreachable!(),
         }
     }
     /// Set command drive phase.
     #[inline]
-    pub fn set_command_drive_phase(self, phase: DDC_TimingPhase) -> Self {
+    pub const fn set_command_drive_phase(self, phase: DdcTimingPhase) -> Self {
         Self((self.0 & !Self::CMD_DRV_PH_SEL) | ((phase as u32) << 16))
     }
 }
@@ -974,10 +974,10 @@ impl DriveDelayControl {
 #[cfg(test)]
 mod tests {
     use super::{
-        AccessMode, Argument, BlockSize, BurstSize, BusWidth, Bus_Width, ByteCount, ClockControl,
-        Command, DDC_TimingPhase, DdrMode, DriveDelayControl, FifoWaterLevel, GlobalControl,
-        Interrupt, InterruptMask, InterruptStateMasked, InterruptStateRaw, NTS_TimingPhase,
-        NewTimingSet, RegisterBlock, Status, TimeOut, TransferDirection,
+        AccessMode, Argument, BlockSize, BurstSize, BusWidth, BusWidthBits, ByteCount,
+        ClockControl, Command, DdcTimingPhase, DdrMode, DriveDelayControl, FifoWaterLevel,
+        GlobalControl, Interrupt, InterruptMask, InterruptStateMasked, InterruptStateRaw,
+        NewTimingSet, NtsTimingPhase, RegisterBlock, Status, TimeOut, TransferDirection,
     };
     use memoffset::offset_of;
     #[test]
@@ -1096,16 +1096,16 @@ mod tests {
     fn struct_bus_width_functions() {
         let mut val = BusWidth(0x0);
 
-        val = val.set_bus_width(Bus_Width::OneBit);
-        assert_eq!(val.bus_width(), Bus_Width::OneBit);
+        val = val.set_bus_width(BusWidthBits::OneBit);
+        assert_eq!(val.bus_width(), BusWidthBits::OneBit);
         assert_eq!(val.0, 0x00000000);
 
-        val = val.set_bus_width(Bus_Width::FourBit);
-        assert_eq!(val.bus_width(), Bus_Width::FourBit);
+        val = val.set_bus_width(BusWidthBits::FourBit);
+        assert_eq!(val.bus_width(), BusWidthBits::FourBit);
         assert_eq!(val.0, 0x00000001);
 
-        val = val.set_bus_width(Bus_Width::EightBit);
-        assert_eq!(val.bus_width(), Bus_Width::EightBit);
+        val = val.set_bus_width(BusWidthBits::EightBit);
+        assert_eq!(val.bus_width(), BusWidthBits::EightBit);
         assert_eq!(val.0, 0x00000002);
     }
 
@@ -1280,21 +1280,18 @@ mod tests {
                 _ => unreachable!(),
             };
 
-            val = val.mask_interrupt(int_tmp);
-            assert!(val.is_interrupt_masked(int_tmp));
+            val = val.unmask_interrupt(int_tmp);
+            assert!(val.is_interrupt_unmasked(int_tmp));
             assert_eq!(val.0, val_tmp);
 
-            val = val.unmask_interrupt(int_tmp);
-            assert!(!val.is_interrupt_masked(int_tmp));
+            val = val.mask_interrupt(int_tmp);
+            assert!(!val.is_interrupt_unmasked(int_tmp));
             assert_eq!(val.0, 0x00000000);
-            
         }
     }
 
     #[test]
     fn struct_interrupt_state_masked_functions() {
-        let mut val = InterruptStateMasked(0x0);
-
         for i in 0..18 as u8 {
             let int_tmp = match i {
                 0x0 => Interrupt::CardRemoved,
@@ -1340,15 +1337,13 @@ mod tests {
                 _ => unreachable!(),
             };
 
-            val = InterruptStateMasked(val_tmp);
+            let val = InterruptStateMasked(val_tmp);
             assert!(val.has_interrupt(int_tmp));
         }
     }
 
     #[test]
     fn struct_interrupt_state_raw_functions() {
-        let mut val =InterruptStateRaw(0x0);
-
         for i in 0..18 as u8 {
             let int_tmp = match i {
                 0 => Interrupt::CardRemoved,
@@ -1394,7 +1389,7 @@ mod tests {
                 _ => unreachable!(),
             };
 
-            val = InterruptStateRaw(val_tmp);
+            let mut val = InterruptStateRaw(val_tmp);
             assert!(val.has_interrupt(int_tmp));
 
             val = InterruptStateRaw(0x0);
@@ -1405,9 +1400,7 @@ mod tests {
 
     #[test]
     fn struct_status_functions() {
-        let mut val = Status(0x0);
-
-        val = Status(0x03FE0000);
+        let mut val = Status(0x03FE0000);
         assert_eq!(val.fifo_level(), 0x1FF);
 
         val = Status(0x00000200);
@@ -1471,10 +1464,10 @@ mod tests {
 
         for i in 0..4 as u8 {
             let tp_tmp = match i {
-                0x0 => NTS_TimingPhase::Offset90,
-                0x1 => NTS_TimingPhase::Offset180,
-                0x2 => NTS_TimingPhase::Offset270,
-                0x3 => NTS_TimingPhase::Offset0,
+                0x0 => NtsTimingPhase::Offset90,
+                0x1 => NtsTimingPhase::Offset180,
+                0x2 => NtsTimingPhase::Offset270,
+                0x3 => NtsTimingPhase::Offset0,
                 _ => unreachable!(),
             };
 
@@ -1496,20 +1489,20 @@ mod tests {
     fn struct_drive_delay_control_functions() {
         let mut val = DriveDelayControl(0x0);
 
-        val = val.set_data_drive_phase(DDC_TimingPhase::Sdr180Ddr90);
-        assert_eq!(val.data_drive_phase(), DDC_TimingPhase::Sdr180Ddr90);
+        val = val.set_data_drive_phase(DdcTimingPhase::Sdr180Ddr90);
+        assert_eq!(val.data_drive_phase(), DdcTimingPhase::Sdr180Ddr90);
         assert_eq!(val.0, 0x00020000);
 
-        val = val.set_data_drive_phase(DDC_TimingPhase::Sdr90Ddr45);
-        assert_eq!(val.data_drive_phase(), DDC_TimingPhase::Sdr90Ddr45);
+        val = val.set_data_drive_phase(DdcTimingPhase::Sdr90Ddr45);
+        assert_eq!(val.data_drive_phase(), DdcTimingPhase::Sdr90Ddr45);
         assert_eq!(val.0, 0x00000000);
 
-        val = val.set_command_drive_phase(DDC_TimingPhase::Sdr180Ddr90);
-        assert_eq!(val.command_drive_phase(), DDC_TimingPhase::Sdr180Ddr90);
+        val = val.set_command_drive_phase(DdcTimingPhase::Sdr180Ddr90);
+        assert_eq!(val.command_drive_phase(), DdcTimingPhase::Sdr180Ddr90);
         assert_eq!(val.0, 0x00010000);
 
-        val = val.set_command_drive_phase(DDC_TimingPhase::Sdr90Ddr45);
-        assert_eq!(val.command_drive_phase(), DDC_TimingPhase::Sdr90Ddr45);
+        val = val.set_command_drive_phase(DdcTimingPhase::Sdr90Ddr45);
+        assert_eq!(val.command_drive_phase(), DdcTimingPhase::Sdr90Ddr45);
         assert_eq!(val.0, 0x00000000);
     }
 }

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -288,8 +288,7 @@ impl<UART: AsRef<RegisterBlock>, const I: usize, PADS: Pads<I>> embedded_io::Rea
         let uart = self.uart.as_ref();
         let len = buffer.len();
         for c in buffer {
-            // FIXME: should be receive_fifo_not_full
-            while uart.usr.read().busy() {
+            while !uart.uart16550.lsr().read().is_data_ready() {
                 core::hint::spin_loop()
             }
             *c = uart.rbr_thr().rx_data();
@@ -306,8 +305,7 @@ impl<UART: AsRef<RegisterBlock>, const I: usize, PADS: Receive<I>> embedded_io::
         let uart = self.uart.as_ref();
         let len = buffer.len();
         for c in buffer {
-            // FIXME: should be receive_fifo_not_full
-            while uart.usr.read().busy() {
+            while !uart.uart16550.lsr().read().is_data_ready() {
                 core::hint::spin_loop()
             }
             *c = uart.rbr_thr().rx_data();


### PR DESCRIPTION
add SMHC registers, field access functions and unit test cases for:
`global_control`, `clock_control`, `timeout`, `bus_width`, `block_size`,
`byte_count`, `command`, `argument`, `interrupt_mask`, `interrupt_state_masked`,
`interrupt_state_raw`, `status`, `fifo_water_level`, `new_timing_set`, `drive_delay_control`

Signed-off-by: Yu Chongbing <bd8ejk@foxmail.com>